### PR TITLE
choose SLN16 over WAV, for sure

### DIFF
--- a/codecs/codec_opus.c
+++ b/codecs/codec_opus.c
@@ -326,6 +326,7 @@ static char *handle_cli_opus_show(struct ast_cli_entry *e, int cmd, struct ast_c
 
 /* Translators */
 static struct ast_translator opustolin = {
+        .table_cost = AST_TRANS_COST_LY_LL_ORIGSAMP,
         .name = "opustolin",
         .src_codec = {
                 .name = "opus",
@@ -348,6 +349,7 @@ static struct ast_translator opustolin = {
 };
 
 static struct ast_translator lintoopus = {
+        .table_cost = AST_TRANS_COST_LL_LY_ORIGSAMP,
         .name = "lintoopus",
         .src_codec = {
                 .name = "slin",
@@ -371,6 +373,7 @@ static struct ast_translator lintoopus = {
 };
 
 static struct ast_translator opustolin12 = {
+        .table_cost = AST_TRANS_COST_LY_LL_ORIGSAMP - 1,
         .name = "opustolin12",
         .src_codec = {
                 .name = "opus",
@@ -393,6 +396,7 @@ static struct ast_translator opustolin12 = {
 };
 
 static struct ast_translator lin12toopus = {
+        .table_cost = AST_TRANS_COST_LL_LY_ORIGSAMP - 1,
         .name = "lin12toopus",
         .src_codec = {
                 .name = "slin",
@@ -415,6 +419,7 @@ static struct ast_translator lin12toopus = {
 };
 
 static struct ast_translator opustolin16 = {
+        .table_cost = AST_TRANS_COST_LY_LL_ORIGSAMP - 2,
         .name = "opustolin16",
         .src_codec = {
                 .name = "opus",
@@ -437,6 +442,7 @@ static struct ast_translator opustolin16 = {
 };
 
 static struct ast_translator lin16toopus = {
+        .table_cost = AST_TRANS_COST_LL_LY_ORIGSAMP - 2,
         .name = "lin16toopus",
         .src_codec = {
                 .name = "slin",
@@ -460,6 +466,7 @@ static struct ast_translator lin16toopus = {
 };
 
 static struct ast_translator opustolin24 = {
+        .table_cost = AST_TRANS_COST_LY_LL_ORIGSAMP - 4,
         .name = "opustolin24",
         .src_codec = {
                 .name = "opus",
@@ -482,6 +489,7 @@ static struct ast_translator opustolin24 = {
 };
 
 static struct ast_translator lin24toopus = {
+        .table_cost = AST_TRANS_COST_LL_LY_ORIGSAMP - 4,
         .name = "lin24toopus",
         .src_codec = {
                 .name = "slin",
@@ -504,6 +512,7 @@ static struct ast_translator lin24toopus = {
 };
 
 static struct ast_translator opustolin48 = {
+        .table_cost = AST_TRANS_COST_LY_LL_ORIGSAMP - 8,
         .name = "opustolin48",
         .src_codec = {
                 .name = "opus",
@@ -526,6 +535,7 @@ static struct ast_translator opustolin48 = {
 };
 
 static struct ast_translator lin48toopus = {
+        .table_cost = AST_TRANS_COST_LL_LY_ORIGSAMP - 8,
         .name = "lin48toopus",
         .src_codec = {
                 .name = "slin",


### PR DESCRIPTION
The Opus Codec allows to proxy the five sampling rates 8, 12, 16, 24, and 48 kHz. That is the internal sampling rate of the library, see `OPUS_SET_MAX_BANDWIDTH`. For those five rates, the library does not up-sample or down-sample. However on default, Asterisk computes the translation costs from the _external_ sample rate – which is 48 kHz always. This leads to the same score for a translation with slin/8000 or slin/16000 for example. When recorded sounds are played (like Music on Hold), Asterisk uses that score to determine which sound file to choose, see `translate.c:ast_translator_best_choice`. Because a translation with slin/16000 has the same score as slin/8000, it is pure luck whether a SLN16 or WAV file is chosen.

For example on one of my installations, Asterisk determined the best choice in the following order:

    1725000 gsm/8000
     825000 slin16/16000
    1725000 g729/8000
    1725000 g722/16000
    1725000 alaw/8000
    1725000 ulaw/8000
     825000 slin/8000
On another installation (only GSM was installed with the first `make install`):

    1725000 gsm/8000
     825000 slin/8000
     825000 slin16/16000
    1725000 g722/16000
    1725000 alaw/8000
    1725000 ulaw/8000
    1725000 g729/8000
In the latter case, WAV was chosen and consequently the Music-on-Hold was narrow-band instead of wide-band. To correct this, Asterisk must be notified that all formats do not up-/down-sample but stay at the original rate. Furthermore, high quality formats get a slightly better score. For example, slin/16000 should be chosen instead of slin/8000. This change does this and removes the ambiguity which translation to choose from.