### PR TITLE
be compatible with Asterisk 14.0.1

### DIFF
--- a/codecs/codec_opus_open_source.c
+++ b/codecs/codec_opus_open_source.c
@@ -32,7 +32,7 @@
 
 /*** MODULEINFO
 	 <depend>opus</depend>
-	 <support_level>core</support_level>
+	 <conflict>codec_opus</conflict>
 ***/
 
 #include "asterisk.h"


### PR DESCRIPTION
renamed the file codec_opus.c to codec_opus_open_source.c
closes seanbright/asterisk-opus#28
