### PR TITLE
enable module on default

### DIFF
--- a/codecs/codec_opus_open_source.c
+++ b/codecs/codec_opus_open_source.c
@@ -33,6 +33,7 @@
 /*** MODULEINFO
 	 <depend>opus</depend>
 	 <conflict>codec_opus</conflict>
+	 <defaultenabled>yes</defaultenabled>
 ***/
 
 #include "asterisk.h"


### PR DESCRIPTION
the module was enabled on default in the past
since Asterisk 13.12 (and Asterisk 14.0.1) is was disabled on default

Because the conflicting Digium module is disabled on default as well,
no Opus module would have been created. This change makes sure, this
open-source module is enabled, as long as nobody enables the module
from Digium.
